### PR TITLE
Adding empty array as final param for exec

### DIFF
--- a/www/touchid.js
+++ b/www/touchid.js
@@ -13,7 +13,7 @@ TouchID.prototype.authenticate = function (successCallback, errorCallback, text)
 };
 
 TouchID.prototype.checkSupport = function (successCallback, errorCallback) {
-    exec(successCallback, errorCallback, "TouchID", "checkSupport");
+    exec(successCallback, errorCallback, "TouchID", "checkSupport", []);
 };
 
 module.exports = new TouchID();


### PR DESCRIPTION
Was running into an error on Android device without touchID support, cordova was complaining that no args.length existed, so by passing the empty array it gets rid of this error.