### PR TITLE
Run commands in threads

### DIFF
--- a/src/ios/TouchID.m
+++ b/src/ios/TouchID.m
@@ -13,67 +13,71 @@
 {
     NSString *text = [command.arguments objectAtIndex:0];
 
-    __block CDVPluginResult* pluginResult = nil;
+    [self.commandDelegate runInBackground:^{
+        __block CDVPluginResult* pluginResult = nil;
 
-    if (NSClassFromString(@"LAContext") != nil)
-    {
-        LAContext *laContext = [[LAContext alloc] init];
-        NSError *authError = nil;
-
-        if ([laContext canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:&authError])
+        if (NSClassFromString(@"LAContext") != nil)
         {
-            [laContext evaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics localizedReason:text reply:^(BOOL success, NSError *error)
-             {
-                 if (success)
-                 {
-                     pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
-                 }
-                 else
-                 {
-                     pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:[error localizedDescription]];
-                 }
+            LAContext *laContext = [[LAContext alloc] init];
+            NSError *authError = nil;
 
-                 [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
-             }];
+            if ([laContext canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:&authError])
+            {
+                [laContext evaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics localizedReason:text reply:^(BOOL success, NSError *error)
+                 {
+                     if (success)
+                     {
+                         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+                     }
+                     else
+                     {
+                         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:[error localizedDescription]];
+                     }
+
+                     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+                 }];
+            }
+            else
+            {
+                pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:[authError localizedDescription]];
+                [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+            }
         }
         else
         {
-            pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:[authError localizedDescription]];
+            pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR];
             [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
         }
-    }
-    else
-    {
-        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR];
-        [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
-    }
+    }];
 }
 
 - (void) checkSupport:(CDVInvokedUrlCommand*)command;
 {
 
-    __block CDVPluginResult* pluginResult = nil;
+    [self.commandDelegate runInBackground:^{
+        __block CDVPluginResult* pluginResult = nil;
 
-    if (NSClassFromString(@"LAContext") != nil)
-    {
-        LAContext *laContext = [[LAContext alloc] init];
-        NSError *authError = nil;
-
-        if ([laContext canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:&authError])
+        if (NSClassFromString(@"LAContext") != nil)
         {
-            pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+            LAContext *laContext = [[LAContext alloc] init];
+            NSError *authError = nil;
+
+            if ([laContext canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:&authError])
+            {
+                pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+            }
+            else
+            {
+                pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:[authError localizedDescription]];
+            }
         }
         else
         {
-            pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:[authError localizedDescription]];
+            pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR];
         }
-    }
-    else
-    {
-        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR];
-    }
 
-    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+    }];
 }
 
 @end


### PR DESCRIPTION
Seems like executing commands in separate threads is what's usually done. Also this removes an annoying runtime warning:

```
2016-05-02 22:02:22.957 Crossover[2563:1224554] THREAD WARNING: ['TouchID'] took '42.695068' ms. Plugin should use a background thread.
```