### PR TITLE
return error code strings in case of failed evaluatePolicy

### DIFF
--- a/src/ios/TouchID.m
+++ b/src/ios/TouchID.m
@@ -30,7 +30,35 @@
                  }
                  else
                  {
-                     pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:[error localizedDescription]];
+                     NSString *errorCode = nil;
+                     switch (error.code) {
+                         case LAErrorAuthenticationFailed:
+                             errorCode = @"authenticationFailed";
+                             break;
+                         case LAErrorUserCancel:
+                             errorCode = @"userCancel";
+                             break;
+                         case LAErrorUserFallback:
+                             errorCode = @"userFallback";
+                             break;
+                         case LAErrorSystemCancel:
+                             errorCode = @"systemCancel";
+                             break;
+                         case LAErrorPasscodeNotSet:
+                             errorCode = @"passcodeNotSet";
+                             break;
+                         case LAErrorTouchIDNotAvailable:
+                             errorCode = @"touchIDNotAvailable";
+                             break;
+                         case LAErrorTouchIDNotEnrolled:
+                             errorCode = @"touchIDNotEnrolled";
+                             break;
+                         default:
+                             errorCode = @"unknown";
+                             break;
+                     }
+                     
+                     pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:errorCode];
                  }
 
                  [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];


### PR DESCRIPTION
In my opinion it's better to return constant Strings (that are close to the error enum) in the case of a failed scan.