### PR TITLE
Adding a boolean to indicate if falling back to passcode authentication is allowed

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,10 @@ Pass the following arguments to the `authenticate()` function, to prompt the use
 1. Success callback (called on successful authentication)
 2. Failure callback (called on error or if authentication fails)
 3. Localised text explaining why the app needs authentication*
+4. Boolean to indicate if falling back to passcode authentication is allowed (default is false, if not provided).
 
 ```
-touchid.authenticate(successCallback, failureCallback, text);
+touchid.authenticate(successCallback, failureCallback, text, true);
 ```
 
 *NOTE: The localised text you present to the user should provide a clear reason for why you are requesting they authenticate themselves, and what action you will be taking based on that authentication.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/leecrossley/cordova-plugin-touchid.git"
+    "url": "git+https://github.com/tsanidas/cordova-plugin-touchid.git"
   },
   "keywords": [
     "cordova",
@@ -33,7 +33,7 @@
   ],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/leecrossley/cordova-plugin-touchid/issues"
+    "url": "https://github.com/tsanidas/cordova-plugin-touchid/issues"
   },
-  "homepage": "https://github.com/leecrossley/cordova-plugin-touchid#readme"
+  "homepage": "https://github.com/tsanidas/cordova-plugin-touchid#readme"
 }

--- a/plugin.xml
+++ b/plugin.xml
@@ -14,7 +14,7 @@
     <platform name="ios">
         <config-file target="config.xml" parent="/*">
             <feature name="TouchID">
-                <param name="ios-package" value="TouchID" />
+                <param name="ios-package" onload="true" value="TouchID" />
             </feature>
         </config-file>
         <header-file src="src/ios/TouchID.h" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -14,7 +14,8 @@
     <platform name="ios">
         <config-file target="config.xml" parent="/*">
             <feature name="TouchID">
-                <param name="ios-package" onload="true" value="TouchID" />
+                <param name="ios-package" value="TouchID" />
+                <param name="onload" value="true" />
             </feature>
         </config-file>
         <header-file src="src/ios/TouchID.h" />

--- a/src/ios/TouchID.m
+++ b/src/ios/TouchID.m
@@ -109,9 +109,9 @@
 {
     BOOL canFallbackToPasscode = NO;
     if (command.arguments.count >= idx+1) {
-        NSString *txtFallbackToPasscode =
-            [command argumentAtIndex:(idx) withDefault:@"false" andClass:[NSString class]];
-        if ([txtFallbackToPasscode isEqualToString:@"true"]) {
+        NSNumber *numFallbackToPasscode =
+            [command argumentAtIndex:(idx) withDefault:@"false" andClass:[NSNumber class]];
+        if (numFallbackToPasscode.intValue == 1) {
             canFallbackToPasscode = true;
         }
     }

--- a/src/ios/TouchID.m
+++ b/src/ios/TouchID.m
@@ -80,7 +80,7 @@
 
 - (void) checkSupport:(CDVInvokedUrlCommand*)command;
 {
-    LAPolicy authPolicy = [self determineLAPolicyFromCommand:command flagIndex:1];
+    LAPolicy authPolicy = [self determineLAPolicyFromCommand:command flagIndex:0];
     __block CDVPluginResult* pluginResult = nil;
 
     if (NSClassFromString(@"LAContext") != nil)

--- a/src/ios/TouchID.m
+++ b/src/ios/TouchID.m
@@ -8,7 +8,9 @@
 #import <LocalAuthentication/LocalAuthentication.h>
 
 @implementation TouchID
-
+- (void)pluginInitialize{
+    NSLog(@"Init-ing");
+}
 - (void) authenticate:(CDVInvokedUrlCommand*)command;
 {
     NSString *text = [command.arguments objectAtIndex:0];

--- a/www/touchid.js
+++ b/www/touchid.js
@@ -5,15 +5,15 @@ var TouchID = function () {
     this.name = "TouchID";
 };
 
-TouchID.prototype.authenticate = function (successCallback, errorCallback, text) {
+TouchID.prototype.authenticate = function (successCallback, errorCallback, text, passcodeFallback) {
     if (!text) {
         text = "Please authenticate via TouchID to proceed";
     }
-    exec(successCallback, errorCallback, "TouchID", "authenticate", [text]);
+    exec(successCallback, errorCallback, "TouchID", "authenticate", [text, passcodeFallback]);
 };
 
-TouchID.prototype.checkSupport = function (successCallback, errorCallback) {
-    exec(successCallback, errorCallback, "TouchID", "checkSupport", []);
+TouchID.prototype.checkSupport = function (successCallback, errorCallback, passcodeFallback) {
+    exec(successCallback, errorCallback, "TouchID", "checkSupport", [passcodeFallback]);
 };
 
 module.exports = new TouchID();


### PR DESCRIPTION
Added one extra boolean param to the authenticate() method, with a default of false so that current functionality is preserved if this is not provided.  If the new last param is true, then it will be ok to show a passcode local auth screen if touch id has not been set up, is not available, or fails.